### PR TITLE
Fixed example code, optimized query process. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *~
 __pycache__
+_*
+*.egg-info/

--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ The code below shows how to use the package (note: currently not tested)
 ```python
 import vortran
 
-lasers = votran.get_lasers()
+lasers = vortran.get_lasers()
 
 laser = lasers[0]
 

--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 
 If you don't have python already on your system you can install it using [uv](https://docs.astral.sh/uv/#installation).
 
-Install the package using uv direclty from the clonsed git repository:
+Install the package using uv directly from the cloned git repository:
 
     uv pip install -e .
 

--- a/Readme.md
+++ b/Readme.md
@@ -19,8 +19,12 @@ lasers = vortran.get_lasers()
 
 laser = lasers[0]
 
+is_open = laser.open_connection()
+
 laser.enable_power_control_mode()
 laser.power = 50
+
+base_temp = laser.base_plate_temperature
 
 laser.on()
 time.sleep(1)

--- a/example.py
+++ b/example.py
@@ -1,4 +1,4 @@
-import votran
+import vortran
 
 if __name__ == "__main__":
     my_connection = []

--- a/src/vortran/__init__.py
+++ b/src/vortran/__init__.py
@@ -1,3 +1,4 @@
 from .usb import get_usb_ports
 from .usb_connection import USB_ReadWrite
 from .laser import Laser, get_lasers
+from .parser import parse_output

--- a/src/vortran/__init__.py
+++ b/src/vortran/__init__.py
@@ -1,4 +1,4 @@
 from .usb import get_usb_ports
 from .usb_connection import USB_ReadWrite
 from .laser import Laser, get_lasers
-from .parser import parse_output
+from .parser import parse_output, verify_result

--- a/src/vortran/laser.py
+++ b/src/vortran/laser.py
@@ -65,10 +65,10 @@ class Laser(USB_ReadWrite):
         self.send_usb("LC={value:05.1f}")
 
     def on(self):
-        self.send_ubs("LE=1")
+        self.send_usb("LE=1")
 
     def off(self):
-        self.send_ubs("LE=0")
+        self.send_usb("LE=0")
 
     @property
     def on_off(self):

--- a/src/vortran/laser.py
+++ b/src/vortran/laser.py
@@ -1,6 +1,7 @@
 from enum import IntFlag
 
 from .usb_connection import USB_ReadWrite
+from .usb import get_usb_ports
 
 
 class LaserStatus(IntFlag):
@@ -189,7 +190,7 @@ def get_lasers():
     lasers = []
     if devices:
         for device in devices:
-            if devices[device]["is_manager"]:
+            if devices[device].is_manager:
                 manager = device
             else:
                 lasers.append(device)

--- a/src/vortran/laser.py
+++ b/src/vortran/laser.py
@@ -1,7 +1,9 @@
 from enum import IntFlag
+from types import NoneType
 
 from .usb_connection import USB_ReadWrite
 from .usb import get_usb_ports
+from .parser import parse_output, verify_result
 
 
 class LaserStatus(IntFlag):
@@ -23,6 +25,12 @@ class LaserStatus(IntFlag):
 
 
 class Laser(USB_ReadWrite):
+    """Class representing laser connections. Its properties are
+    wrappers around different commands. To see the possible values of
+    each function result, please consult the manual.
+
+    """
+
     def enable_power_control_mode(self):
         self.send_usb("C=0")
 
@@ -31,8 +39,8 @@ class Laser(USB_ReadWrite):
 
     @property
     def control_mode(self):
-        self.send_usb("?C")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?C")
+        return parse_output(self.send_query("?C"))
 
     def enable_delay(self):
         self.send_usb("DELAY=0")
@@ -42,8 +50,8 @@ class Laser(USB_ReadWrite):
 
     @property
     def delay(self):
-        self.send_usb("?DELAY")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?DELAY")
+        return parse_output(self.send_query("?DELAY"))
 
     def enable_external_power_control(self):
         self.send_usb("EPC=1")
@@ -53,13 +61,13 @@ class Laser(USB_ReadWrite):
 
     @property
     def external_power_control(self):
-        self.send_usb("?EPC")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?EPC")
+        return parse_output(self.send_query("?EPC"))
 
     @property
     def current(self):
-        self.send_usb("?LC")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?LC")
+        return parse_output(self.send_query("?LC"))
 
     @current.setter
     def current(self, value):
@@ -74,12 +82,12 @@ class Laser(USB_ReadWrite):
     @property
     def on_off(self):
         self.send_usb("?LE")
-        return self.read_usb(timeout=1)
+        return parse_output(self.send_query("?LE"))
 
     @property
     def power(self):
-        self.send_usb("?LP")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?LP")
+        return parse_output(self.send_query("?C"))
 
     @power.setter
     def power(self, value):
@@ -87,8 +95,8 @@ class Laser(USB_ReadWrite):
 
     @property
     def pulse_power(self):
-        self.send_usb("?PP")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?PP")
+        return parse_output(self.send_query("?PP"))
 
     @pulse_power.setter
     def pulse_power(self, value):
@@ -102,88 +110,121 @@ class Laser(USB_ReadWrite):
 
     @property
     def pulsed_power(self):
-        self.send_usb("?PUL")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?PUL")
+        return parse_output(self.send_query("?PUL"))
 
     @property
     def base_plate_temperature(self):
-        self.send_usb("?BPT")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?BPT")
+        return parse_output(self.send_query("?BPT"))
 
     @property
     def computer_control(self):
-        self.send_usb("?CC")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?CC")
+        return parse_output(self.send_query("?CC"))
 
     @property
     def fault_code(self):
-        self.send_usb("?FC")
+        self.send_query("?FC")
         fault = self.read_usb(timeout=1)
-        fault = LaserStatus(fault)
-        return fault
+        if (
+            fault is not None
+            and verify_result(fault, "?FC") == True
+            and parse_output(fault) is not None
+        ):
+            result = parse_output(fault)[0]  # type: ignore
+            fault = LaserStatus(
+                result
+            )  # returns an error, might require parsing to get single value
+            return list(fault)
+        else:
+            return None
 
     @property
     def fault_text(self):
-        self.send_usb("?FD")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?FD")
+        return parse_output(self.send_query("?FD"))
 
     @property
     def firmware_protocal(self):
-        self.send_usb("?FP")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?FP")
+        return parse_output(self.send_query("?FP"))
 
     @property
     def firmware_version(self):
-        self.send_usb("?FV")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?FV")
+        return parse_output(self.send_query("?FV"))
 
     @property
     def interlock_status(self):
-        self.send_usb("?IL")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?IL")
+        return parse_output(self.send_query("?IL"))
 
     @property
     def laser_hours(self):
-        self.send_usb("?LH")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?LH")
+        return parse_output(self.send_query("?LH"))
 
     @property
     def laser_id(self):
-        self.send_usb("?LI")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?LI")
+        return parse_output(self.send_query("?LI"))
 
     @property
     def laser_power_setting(self):
-        self.send_usb("?LPS")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?LPS")
+        return parse_output(self.send_query("?LPS"))
 
     @property
     def laser_status(self):
-        self.send_usb("?LS")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?LS")
+        return parse_output(self.send_query("?LS"))
 
     @property
     def laser_wavelength(self):
-        self.send_usb("?LW")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?LW")
+        return parse_output(self.send_query("?LW"))
 
     @property
     def laser_max_power(self):
-        self.send_usb("?MAXP")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?MAXP")
+        return parse_output(self.send_query("?MAXP"))
 
     @property
     def optical_block_temperature(self):
-        self.send_usb("?OBT")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?OBT")
+        return parse_output(self.send_query("?OBT"))
 
     @property
     def rated_power(self):
-        self.send_usb("?RP")
-        return self.read_usb(timeout=1)
+        # self.send_usb("?RP")
+        return parse_output(self.send_query("?RP"))
+
+    def send_query(self, command: str) -> str | None:
+        """Sends a query command to the laser and returns the
+        result. If the result is None or empty, it tries again before
+        returning None.
+
+        """
+        result = self.send_usb(command)
+        if result is not None and verify_result(result, command) == True:
+            data = result
+        else:  # if result is None or not verified, ask again
+            second_try = self.send_usb(command)
+            if result is not None and verify_result(result, command) == True:
+                data = result
+            else:
+                data = None
+
+        return data
 
 
 def get_lasers():
+    """Returns a list containing possible connections to
+    lasers. First laser is index 0 of the return value.
+
+    """
+
     connections = []
 
     devices = get_usb_ports()

--- a/src/vortran/parser.py
+++ b/src/vortran/parser.py
@@ -4,16 +4,38 @@ parser.py
 File to parse the output string from the laser.
 """
 
+from types import NoneType
 
-def parse_output(input: str) -> list[str]:
-    lines = input.splitlines()[1:]  # first element is always empty
 
-    # TODO: return error if there is only one element in the list, which means no data
+def parse_output(input: str | NoneType) -> list[str] | NoneType:
+    """Parses response from microcontroller to seperate out the
+    important data. Returns the data as a variable-length list.
+    """
 
-    result = []
+    if input != None:
+        lines = input.splitlines()[1:]  # first element is always empty
 
-    for datum in lines[:-1]:
-        info = datum.split("=")[1].strip()
-        result.append(info)
+        # TODO: return error if there is only one element in the list, which means no data
+
+        result = []
+
+        for datum in lines[:-1]:
+            info = datum.split("=")[1].strip()
+            result.append(info)
+
+    else:
+        result = None
+
+    return result
+
+
+def verify_result(input: str, command: str) -> bool:
+    """Verifies if a response has data by looking for the command
+    string inside.
+    """
+
+    index = input.find(command)
+
+    result = True if (index != -1) else False
 
     return result

--- a/src/vortran/parser.py
+++ b/src/vortran/parser.py
@@ -1,0 +1,19 @@
+"""
+parser.py
+
+File to parse the output string from the laser.
+"""
+
+
+def parse_output(input: str) -> list[str]:
+    lines = input.splitlines()[1:]  # first element is always empty
+
+    # TODO: return error if there is only one element in the list, which means no data
+
+    result = []
+
+    for datum in lines[:-1]:
+        info = datum.split("=")[1].strip()
+        result.append(info)
+
+    return result

--- a/src/vortran/usb.py
+++ b/src/vortran/usb.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
+
+# Note: these are imports from pyusb
 import usb.core
 import usb.backend.libusb1
+
 import re
 import platform
 

--- a/src/vortran/usb.py
+++ b/src/vortran/usb.py
@@ -106,7 +106,7 @@ def get_usb_ports():
     return found_vortran_devices
 
 
-def parse_bus_and_address(text: str) -> (int, int):
+def parse_bus_and_address(text: str) -> tuple[int, int]:
     """Get the bus and address from the usb string."""
 
     # TRY TO FIND BUS AND ADDRESS
@@ -129,4 +129,5 @@ def parse_bus_and_address(text: str) -> (int, int):
                 address = int(tmp_match_address.groups()[0])
             except ValueError:
                 print("Unable to get a bus in utility get_usb_ports")
+
     return bus, address

--- a/src/vortran/usb_connection.py
+++ b/src/vortran/usb_connection.py
@@ -9,7 +9,7 @@ import array
 import logging
 import time
 
-#from .usb import VortranDevice
+# from .usb import VortranDevice
 from .usb import *
 
 
@@ -22,7 +22,7 @@ class USB_ReadWrite:
     def __init__(
         self,
         laser: VortranDevice,
-        timeout,
+        timeout,  # Why is this here?
         retries=1,
         logger=None,
         is_protocol_laser=True,
@@ -72,11 +72,11 @@ class USB_ReadWrite:
                     arch = platform.architecture()
                     if arch[0] == "32bit":
                         backend = usb.backend.libusb1.get_backend(
-                            find_library=lambda x: "USB/libusb/x86/libusb-1.0.dll"
+                            find_library=lambda: "USB/libusb/x86/libusb-1.0.dll"
                         )
                     elif arch[0] == "64bit":
                         backend = usb.backend.libusb1.get_backend(
-                            find_library=lambda x: "USB/libusb/x64/libusb-1.0.dll"
+                            find_library=lambda: "USB/libusb/x64/libusb-1.0.dll"
                         )
                     else:
                         raise Exception(
@@ -138,7 +138,7 @@ class USB_ReadWrite:
         try:
             data = self.connection.read(0x81, 64, timeout)
         except usb.core.USBError:
-            print("Error reading response: {e.args}: {str(timeout)}")
+            print(f"Error reading response: {e.args}: {str(timeout)}")
             return None
 
         if include_first_byte:
@@ -156,7 +156,7 @@ class USB_ReadWrite:
             cmd = cmd + "\r\n"
         stripped_cmd = cmd.replace("\r\n", "").lower()
         try:
-            response = self.read_usb(30)
+            response = self.read_usb(timeout=30)
             if self.is_protocol_laser:
                 data = bytearray(cmd, "ascii")
                 padding = bytearray([0xFF] * (63 - len(cmd)))

--- a/src/vortran/usb_connection.py
+++ b/src/vortran/usb_connection.py
@@ -9,7 +9,8 @@ import array
 import logging
 import time
 
-from .usb import VortranDevice
+#from .usb import VortranDevice
+from .usb import *
 
 
 class USB_ReadWrite:

--- a/src/vortran/usb_connection.py
+++ b/src/vortran/usb_connection.py
@@ -154,7 +154,9 @@ class USB_ReadWrite:
         workflow_timeout = 0.05
         if not cmd.endswith("\r\n"):
             cmd = cmd + "\r\n"
-        stripped_cmd = cmd.replace("\r\n", "").lower()
+        stripped_cmd = (
+            cmd.replace("\r\n", "").lower()
+        )  # This part doesn't make sense given how the example code calls commands.
         try:
             response = self.read_usb(timeout=30)
             if self.is_protocol_laser:


### PR DESCRIPTION
This pull request aimed to address a few priorities:

- Small typos in the existing code prevented it from running
- Query calls used usb_send() and then usb_read(), which is a redundant operation
- Fixed example code to specify that programs must use open_connection() before sending commands or querys